### PR TITLE
Specify env at job level

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,10 +10,22 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
+    
     defaults:
       run:
         working-directory: dev
-
+    
+    env:
+      AWS_ACCESS_KEY_ID:     ${{ secrets.DEV_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_SECRET_KEY }}
+      AWS_DEFAULT_REGION:    ${{ secrets.DEV_REGION }}
+      TF_VAR_access_key:     ${{ secrets.DEV_ACCESS_KEY }}
+      TF_VAR_secret_key:     ${{ secrets.DEV_SECRET_KEY }}
+      TF_VAR_region:         ${{ secrets.DEV_REGION }}
+      TF_VAR_cf_user:        ${{ secrets.DEV_CF_USER }}
+      TF_VAR_cf_password:    ${{ secrets.DEV_CF_PASSWORD }}
+      TF_VAR_uev_key:        ${{ secrets.DEV_UEV_KEY }}
+    
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -32,10 +44,6 @@ jobs:
 
     - name: Terraform Init
       run: terraform init -input=false
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.DEV_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_SECRET_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.DEV_REGION }}
 
     - name: Terraform Format
       run: terraform fmt -check
@@ -43,16 +51,6 @@ jobs:
     - name: Terraform Plan
       id: plan
       run: terraform plan -input=false -no-color
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.DEV_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_SECRET_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.DEV_REGION }}
-        TF_VAR_access_key: ${{ secrets.DEV_ACCESS_KEY }}
-        TF_VAR_secret_key: ${{ secrets.DEV_SECRET_KEY }}
-        TF_VAR_region: ${{ secrets.DEV_REGION }}
-        TF_VAR_cf_user: ${{ secrets.DEV_CF_USER }}
-        TF_VAR_cf_password: ${{ secrets.DEV_CF_PASSWORD }}
-        TF_VAR_uev_key: ${{ secrets.DEV_UEV_KEY }}
 
     - name: Create Plan Comment
       uses: actions/github-script@0.9.0


### PR DESCRIPTION
Previously, the `terraform apply` step failed bc it didn't have the necessary env vars.