### PR TITLE
Remove ECR repo env var for Circle

### DIFF
--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -91,7 +91,6 @@ locals {
     AWS_ECR_WRITE_KEY    = module.ecr.write_key
     AWS_ECR_WRITE_SECRET = module.ecr.write_secret
     AWS_ECR_ACCOUNT_URL  = module.ecr.account_url
-    AWS_ECR_REPO         = module.ecr.repo
     AWS_ECR_REGION       = data.aws_region.current_govcloud.name
   }
 }

--- a/terraform/modules/sns/main.tf
+++ b/terraform/modules/sns/main.tf
@@ -23,11 +23,6 @@ resource "aws_sns_topic" "topic" {
   tags = var.tags
 }
 
-resource "aws_sns_topic_policy" "topic_policy" {
-  arn    = aws_sns_topic.topic.arn
-  policy = data.aws_iam_policy_document.topic_policy_document.json
-}
-
 # The "email" protocol is not currently supported by Terraform since it needs to be manually confirmed
 # This needs to be added manually in the console
 #
@@ -36,38 +31,3 @@ resource "aws_sns_topic_policy" "topic_policy" {
 #   protocol  = "email"
 #   endpoint  = "federalist-alerts@gsa.gov"
 # }
-
-data "aws_iam_policy_document" "topic_policy_document" {
-  policy_id = "__default_policy_ID"
-
-  statement {
-    sid = "__default_statement_ID"
-
-    actions = [
-      "SNS:Subscribe",
-      "SNS:SetTopicAttributes",
-      "SNS:RemovePermission",
-      "SNS:Receive",
-      "SNS:Publish",
-      "SNS:ListSubscriptionsByTopic",
-      "SNS:GetTopicAttributes",
-      "SNS:DeleteTopic",
-      "SNS:AddPermission",
-    ]
-
-    effect    = "Allow"
-    resources = [aws_sns_topic.topic.arn]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "AWS:SourceOwner"
-
-      values = [data.aws_caller_identity.default.account_id]
-    }
-  }
-}


### PR DESCRIPTION
The repo name must be passed as a parameter to the AWS ECR orb so we must hardcode it so the env var is not useful.