### PR TITLE
Creates the Terraform infrastructure for Production

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,7 +35,6 @@ jobs:
             name: Staging
             cf_user: CF_USER_STAGING
             cf_password: CF_PASSWORD_STAGING
-        include:
           - env: production
             name: Production
             cf_user: CF_USER_PRODUCTION

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,12 +29,17 @@ jobs:
 
     strategy:
       matrix:
-        env: [staging]
+        env: [production, staging]
         include:
           - env: staging
             name: Staging
             cf_user: CF_USER_STAGING
             cf_password: CF_PASSWORD_STAGING
+        include:
+          - env: production
+            name: Production
+            cf_user: CF_USER_PRODUCTION
+            cf_password: CF_PASSWORD_PRODUCTION
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In the AWS Console for each platform
     ]
   }
   ```
-  where each `<role_arn>` corresponds to the assume role arn created when bootstrapping an environment. These can be added now if they are known, or they can be added as created later on. They will look like: `arn:aws-us-gov:iam::<account id>:role/terraform-user-role`.
+  where each `<role_arn>` corresponds to the assume role arn created when bootstrapping an environment. These can be added now if they are known, or they can be added as created later on. Ex. For GovCloud, they will look like: `arn:aws-us-gov:iam::<account id>:role/terraform-user-role`.
 
 ## Bootstrapping environments
 Before using Terraform to manage resources for a Federalist environment, we need to create a role with appropriate permissions in each AWS account associated with the environment. Since a Federalist environment may need to manage resources in both Commercial and GovCloud accounts AND accounts on different AWS platforms cannot interact, we must run this step for each one. In the steps below, `<platform>` can be either `commercial` or `govcloud` and `<env>` can be `staging` or `production`. This only needs to be done once when creating an environment completely from scratch OR when updating the Terraform role permissions. 

--- a/terraform/production/terraform.tfvars
+++ b/terraform/production/terraform.tfvars
@@ -1,4 +1,5 @@
 aws_region_govcloud          = "us-gov-west-1"
-aws_assume_role_arn_govcloud = "arn:aws-us-gov:iam::902143644410:role/terraform-user-role"
-# aws_region_commercial = "us-east-1"
-# aws_assume_role_arn_commercial = "arn:aws-us-gov:iam::960119293461:role/terraform-user-role"
+aws_assume_role_arn_govcloud = "arn:aws-us-gov:iam::441879447884:role/terraform-user-role"
+
+# aws_region_commercial          = "us-east-1"
+# aws_assume_role_arn_commercial = "arn:aws:iam::312530187933:role/terraform-user-role"

--- a/terraform/staging/terraform.tfvars
+++ b/terraform/staging/terraform.tfvars
@@ -1,4 +1,5 @@
 aws_region_govcloud          = "us-gov-west-1"
 aws_assume_role_arn_govcloud = "arn:aws-us-gov:iam::902143644410:role/terraform-user-role"
-# aws_region_commercial = "us-east-1"
-# aws_assume_role_arn_commercial = "arn:aws-us-gov:iam::960119293461:role/terraform-user-role"
+
+# aws_region_commercial          = "us-east-1"
+# aws_assume_role_arn_commercial = "arn:aws:iam::960119293461:role/terraform-user-role"


### PR DESCRIPTION
I believe the only thing that should remain unchanged is the UPS in cloud.gov with the SQS creds. Everything else is created anew in GovCloud since it's currently in Commercial OR is being replaced (ECR).

When this is complete, we'll need to restage the federalist app, then builder to start reading from the new queue. There will be a slight delay in builds when this happens.

PR to update the garden build to use the new env vars for production is forthcoming.